### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-##Hardware Requirements
+## Hardware Requirements
 The following equipment will be required:  
 1. You will need 3 computers with the hard drives still installed  
 2. You will need 1 computer shell (a computer with the hard drive removed)  
@@ -29,7 +29,7 @@ The following equipment will be required:
 5. You will need 1 USB stick for storing the applications gpg private key  
 6. A USB stick will be needed for each journalist for storing their personnel gpg private keys  
 
-##Local Certificate Authority Install  
+## Local Certificate Authority Install  
 The journalist's interface uses ssl certificates for transport encryption and authentication that will be generated on the Local CA USB stick.  
 
 1. Steps to download, verify and install Tails to a usb stick can be found here https://tails.boum.org/download/index.en.html  
@@ -44,7 +44,7 @@ The journalist's interface uses ssl certificates for transport encryption and au
 9. Server and user certificates should be set to expire to your organization's policy  
 10. A User certificate should be revoked if the journalist no longer requires access  
 
-###Setup openssl
+### Setup openssl
 The configuration files, certificates, and revocation lists are saved in the Persistant folder activated with the Personal Data feature of the Tails Persistent Volume Feature.
 
 	mkdir -p /home/amnesia/Persistent/deaddropCA/{private,newcerts,certs,usercerts,crl}  
@@ -84,7 +84,7 @@ Update the OpenSSL environment variable to use the new config file
 
         export OPENSSL_CONF=/home/amnesia/Persistent/deaddropCA/openssl.cnf  
         
-####Generate the needed certificates
+#### Generate the needed certificates
 Generate the CA cert and revocation list. Adjust the expirations to meet your organization's policy:  
 
 	openssl ecparam -name prime256v1 -genkey -out private/cakey.pem  
@@ -117,18 +117,18 @@ Copy the needed certs to the app's external harddrive
 	cp crl/cacrl.pem ~/journalist_certs/  
 	cp certs/{cacert.pem,journalist.cert.pem} ~/journalist_certs/  
 
-##Configure Secure-Viewing-Station and Application's GPG keypair
+## Configure Secure-Viewing-Station and Application's GPG keypair
 
-###Create Ubuntu LiveCD and prepare the SVS  
+### Create Ubuntu LiveCD and prepare the SVS  
 https://help.ubuntu.com/community/LiveCD  
 Remove the hard drive containing the Local CA (after copying the generated certificates to the monitor server)  
 Boot from the SVS from the LiveCD   
 
-###Create the Application's GPG keypair  
+### Create the Application's GPG keypair  
 Insert the app's secure keydrive into the SVS  
 Use an external hard drives rather than a external flash drives. A GPG v1 key will not work with the DeadDrop application. gnupg2 is not required to decrypt messages and files, only to create keys. Use an external entropy device when possible, if one is not available use /dev/random  
 
-####Install required dependencies and create the gpg v2 keys
+#### Install required dependencies and create the gpg v2 keys
 
 	apt-get install gnupg2 secure-delete rng-tools -y  
 	
@@ -161,7 +161,7 @@ Export the Journalist's gpg public key
 
 	gpg2 --export --output journalist.acs --armor Journalist  
 
-####Determine and record the application's gpg key's fingerprint  
+#### Determine and record the application's gpg key's fingerprint  
 
 	gpg --homedir /var/www/deaddrop/keys --list-keys --with-fingerprint  
  
@@ -171,13 +171,13 @@ it will then show you the key's fingerprint. It should look like the line below.
 
 	CCCC CCCC CCCC CCCC CCCC  CCCC CCCC CCCC CCCC CCCC  
 
-##Install and configure puppet
+## Install and configure puppet
 Puppet is used to install the deaddrop application and configure the environment. Efforts were taken to apply the security hardening steps. To keep the attack surface to a minimum uninstall puppet after the environment is configured.
 https://help.ubuntu.com/12.04/serverguide/puppet.html
 
-###Monitor Server
+### Monitor Server
 -----------  
-####Set the hostname if not already done  
+#### Set the hostname if not already done  
 
 	nano /etc/hostname  
 	
@@ -185,7 +185,7 @@ https://help.ubuntu.com/12.04/serverguide/puppet.html
 
 	hostname -F /etc/hostname  
 
-####Edit the /etc/hosts file  
+#### Edit the /etc/hosts file  
 It should look something like below  
 
 	nano /etc/hosts  
@@ -199,7 +199,7 @@ It should look something like below
 >xxx.xxx.xxx.xxx intvpn.domain_name    intvpn  
 >xxx.xxx.xxx.xxx intfw.domain_name    intfw  
 
-####Install the puppetmaster and dependencies  
+#### Install the puppetmaster and dependencies  
 When promted during iptables-persistent install hit *yes* for the IP address version you are using. This guide uses IPv4 enter **yes** when prompted.  
 
 	sudo apt-get install puppetmaster iptables-persistent rubygems sqlite3 libsqlite3-ruby git -y  
@@ -236,7 +236,7 @@ Edit **/etc/puppet/puppet.conf** adding the following lines:
 >thin_storeconfigs = true  
 >dbadpter = sqlite3  
 
-####Gather the required files from the external harddrives  
+#### Gather the required files from the external harddrives  
 From the Secure Viewing Station's:  
 App's pub gpg key `/etc/puppet/modules/deaddrop/files`  
 
@@ -246,7 +246,7 @@ Journalist Interface's SSL private key `/etc/puppet/modules/deaddrop/files/journ
 Local CA's root CA cert `/etc/puppet/modules/deaddrop/files/journalist_certs/`  
 Local CA's CRL list `/etc/puppet/modules/deaddrop/files/journalist_certs/`
 
-#####Modify the default parameters  
+##### Modify the default parameters  
 Modify parameters and hostnames the first section of nodes.pp manifest  
 
 	nano /etc/puppet/manifests/nodes.pp  
@@ -273,12 +273,12 @@ Modify parameters and hostnames the first section of nodes.pp manifest
 >    $mailserver_ip               = 'gmail-smtp-in.l.google.com'  
 >    $ossec_emailto               = 'user_name@gmail.com'  
 
-####Restart the puppetmaster
+#### Restart the puppetmaster
 
 	/etc/init.d/puppetmaster restart
 
 ------------------------
-###Install Puppet on the Source and Journalist servers  
+### Install Puppet on the Source and Journalist servers  
 ------------------------
 
 	apt-get install puppet iptables-persistent  
@@ -303,20 +303,20 @@ Start the puppet agent on the source and journalist server
 
 	/etc/init.d/puppet restart  
 
-###Sign the puppet agent certs on the Monitor server  
+### Sign the puppet agent certs on the Monitor server  
 
 	puppetca --list --all   
 	puppetca --sign --all
 
-###Run the puppet manifest to configure the environment  
+### Run the puppet manifest to configure the environment  
 Run puppet on the 1) monitor server, 2) journalist interface server, 3) source interface server  
 
 	puppet agent --server monitor.domain_name -t  
 	
-##Steps for the system admins to create keys for Google's 2 Step Authenticator PAM module  
+## Steps for the system admins to create keys for Google's 2 Step Authenticator PAM module  
 Ensure that you are not root. Each user that needs SSH access will need to perform these steps. The same key can be used for all devices in the same environment. If the ios/android device and the servers are more than 30 seconds off the codes will not work. Currently the puppet manifest only downloads and partially install google-authenticator it does not enable it. Was worried that people may lock themselves out. You can read more about it at https://code.google.com/p/google-authenticator/    
 
-###Each admin should create their own code  
+### Each admin should create their own code  
 Create the code  
 
 	cd ~  
@@ -354,13 +354,13 @@ Copy you secret key to the other hosts with a command like this one
 
 	scp /home/user_name/.google-authenticator user_name@source:.  
 
-##Create a grsec patched kernel with the ubuntu-precise overlay .deb package  
+## Create a grsec patched kernel with the ubuntu-precise overlay .deb package  
 The grsecurity wikibook should be read thoroughly.
 http://en.wikibooks.org/wiki/Grsecurity  
 The steps for creating a grsec patched kernel with a ubuntu overlay were based from the following link. Please read that blog post for more information.  
 http://compilefailure.blogspot.com/2011/02/grsecurity-patched-ubuntu-server-lts.html  
 
-###Gather files and packages needed for the ubuntu overlay  
+### Gather files and packages needed for the ubuntu overlay  
 
 	cd ~  
 	mkdir grsec  
@@ -397,7 +397,7 @@ Verify the packages
 	bunzip2 linux-3.2.36.tar.bz2  
 	gpg --verify linux-3.2.36.tar.sign  
 
-###Apply the patch to the kernel and make the grsec kernel
+### Apply the patch to the kernel and make the grsec kernel
 
 	tar -xf linux-3.2.36.tar  
 	cd linux-3.2.36  
@@ -425,7 +425,7 @@ In the gui:
 	make-kpkg --initrd --overlay-dir=../ubuntu-package kernel_image kernel_headers  
 
 Grab a cup of coffee. When the package is complete scp the .deb files to all the servers.  
-###Resolve PAX grub issues    
+### Resolve PAX grub issues    
 
 	apt-get install paxctl -y  
 	paxctl -Cpm /usr/sbin/grub-probe  
@@ -435,7 +435,7 @@ Grab a cup of coffee. When the package is complete scp the .deb files to all the
 	paxctl -Cpm /usr/bin/grub-mount  
 	update-grub  
 
-###Install the grsec patched kernel  
+### Install the grsec patched kernel  
 
 	cd ..  
 	dpkg -i *.deb  
@@ -458,7 +458,7 @@ After finishing installing the ensure the grsec sysctl configs are applied and l
     sysctl -w kernel.grsecurity.grsec_lock = 1  
 
 
-##Clean up the system and puppet firewall rules  
+## Clean up the system and puppet firewall rules  
 Once the environment is verified, uninstall puppet on the puppetmaster and puppet agents to decrease the attack surface  
 
 	apt-get purge rubygems puppetmaster puppet gcc make libncurses5-dev build-essential  kernel-package git-core g++ python-setuptools sqlite3 libsqlite3-ruby  

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -1,11 +1,11 @@
-#DeadDrop Threat Model  
+# DeadDrop Threat Model  
 ---------------------  
 
-##Application Name and Description  
+## Application Name and Description  
 DeadDrop is meant to let sources communicate with journalists with greater anonymity and security than afforded by conventional e-mail.
 
 
-##Business Objectives  
+## Business Objectives  
 * Design an application that provides a source a way to securely upload documents and messages to a journalist that protects the source's anonymity.  
 * Design an environment to host the application that protects the source's anonymity.  
 * The application should allow for the source to return to the site and check for replies from the journalist.  
@@ -17,7 +17,7 @@ DeadDrop is meant to let sources communicate with journalists with greater anony
 * The application and environment should be designed to protect the encrypted files even in the event of a full system compromise or seizure.  
 
 
-##Anonymity Provided
+## Anonymity Provided
 * A Tor hidden service is configured for the application. It is highly recommended for the source to use Tor to submit messages, documents and check for replies. Please consult this link for more information on Tor and Tor hidden services https://www.torproject.org/docs/hidden-services.html.en  
 * Only the two selected journalists have physical access to the application's GPG private key and know the key's passphrase used to decrypt source files. These steps were taken to provide reasonable assurance that only the two selected journalists could decrypt the files after they were encrypted in the application.   
 * The network firewall only detects the tor traffic not information about the source.  
@@ -30,8 +30,8 @@ DeadDrop is meant to let sources communicate with journalists with greater anony
 * The source is urged to delete replies after reading them. The application uses secure-remove to delete the file and it is not reasonably forensically recoverable.
 * To ensure that the physical devices are not tampered with the network firewalls, source interface, journalist interface and monitors servers are located in a corporate owned facility (not a co-location hosting provider or cloud provider).   *The environment is physically monitored 24/7 with strict access policies.  
 
-##Application Usage  
-###Source's Role  
+## Application Usage  
+### Source's Role  
 (S1) The organization's Tor hidden service URL, directions, and links to the Tor single-purpose browser are displayed organization's website. The source downloads and installs the Tor single-purpose browser from https://torproject.org. The source uses the site's hidden service URL (.onion) to use the application with a higher level of anonymity than a HTTPS url can provide.  
 
 (S2) A link to the privacy statement is provided.  
@@ -52,7 +52,7 @@ DeadDrop is meant to let sources communicate with journalists with greater anony
 
 (S10) Once the message is displayed, the source is provided the option to delete it per the previous warning. The secure-delete package's srm command is used to securely wipe the journalist's encrypted message from the source's encrypted file store.  
 
-###Journalist's Role  
+### Journalist's Role  
 (J1) From the journalist's workstation, the journalist VPNs into the tips environment through a VPN tunnel that does not allow split-tunneling and has been configured for 2-factor authentication. The journalist interface requires SSL client certificates for access. The journalist will need to have their user certificate installed into their browser to access the journalist interface.  
 
 (J2) Once the journalist's SSL user certificate is validated, the journalist is presented a list of source code IDs that have submitted documents. The source code IDs that are presented to the journalist is a different 3-word code IDs from the source’s clear text codename. The application generates the separate code IDs using the hashes of the sources’ codenames. This is done so that the source's clear text codename is not known to the journalist. A journalist will not request the source’s clear text codename and the source should not include it in any uploaded files or messages. 
@@ -69,7 +69,7 @@ DeadDrop is meant to let sources communicate with journalists with greater anony
 
 (J8) The journalist's interface also has a reply function. The journalist can enter their message for a specific source into a text box and click 'Submit.' The application retrieves the source's GPG public key based off of the source's hashed codename. If the journalist cannot access the source's GPG public key, the reply function is not rendered. The application encrypts the journalist reply with a unique source's GPG public key, which is stored in the source's hashed codename-encrypted file store.  
 
-##Authentication    
+## Authentication    
 * VPN authentication requires 1) username, 2) follows the organization's password complexity policy, and 3) requires 2-factor authentication such as the one from DUO Security.  
 
 * Admin SSH access should require 1) 2-factor authentication, such as Google 2-factor pam module, 2) following the organization's policy for password complexity, and 3) access restricted to the admin's internal vpn address.  
@@ -96,7 +96,7 @@ DeadDrop is meant to let sources communicate with journalists with greater anony
 
 * Admin access to the network firewall should be restricted to the admin's internal VPN IP address.  
 
-##Security Monitoring  
+## Security Monitoring  
 * Security email alerts are sent to the configured admin distribution email address in the puppet config.  
 * VPN User access  
 * Network firewall configuration changes  
@@ -117,7 +117,7 @@ DeadDrop is meant to let sources communicate with journalists with greater anony
 * “Is it up” site monitoring should be performed with a tool that does not require an agent to be installed in the environment to limit the attack surface.  
 
 
-##Security Mailing Lists  
+## Security Mailing Lists  
 Network Firewall ____________________  
 DeadDrop https://github.com/deaddrop  
 Tor https://lists.torproject.org/cgi-bin/mailman/listinfo/tor-announce/  


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
